### PR TITLE
chore(docs): Add section explaining when the plugin is not needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Automatically generates a `_headers` file and a `_redirects` file at the root of
 
 By default, the plugin will add some basic security headers. You can easily add or replace headers through the plugin config.
 
+**When not to use the plugin:** In case you just want to use a `_redirects` or `_headers` file for Netlify with Gatsby, you don't need this plugin. Instead, move those files in `/static/_redirects`, `/static/_headers` and Gatsby will copy them to your root folder during build where Netlify will pick them up.
+
 ## Install
 
 `npm install gatsby-plugin-netlify`


### PR DESCRIPTION
People like me, who google for "netlify redirect gatsby" will likely end up here and think the whole plugin with all it's dependencies is needed, which is not the case. Lets tell them and make their lives easier …