### PR TITLE
ci: update release-please workflow to run yarn

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,6 +27,9 @@ jobs:
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
+      - name: Install dependencies
+        run: yarn
+        if: ${{ steps.release.outputs.release_created }}
       - run: npm publish
         if: ${{ steps.release.outputs.release_created }}
         env:


### PR DESCRIPTION
The GitHub Action that invokes release-please was not publishing the npm package.

This PR ensures that the workflow runs yarn so the package can be successfully published.