### PR TITLE
chore: add lint to ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "format:other": "npm run prettier -- --write",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "prettier": "prettier \"**/*.{md,css,scss,yaml,yml}\"",
-    "test": "jest",
+    "test": "run-s test:jest lint",
+    "test:jest": "jest",
     "watch": "tsc --watch"
   },
   "engines": {


### PR DESCRIPTION
As we're already running `yarn test` in CI, this just changes the package.json script to include a lint check in that phase. 