### PR TITLE
fix: redirect named splat filesystem routes correctly for SSR/DSG pages

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -78,7 +78,7 @@ export const onPostBuild = async ({ store, pathPrefix, reporter }: any, userPlug
     const { mode, matchPath, path } = page
     if (mode === `SSR` || mode === `DSG`) {
       needsFunctions = true
-      const fromPath = matchPath ?? path
+      const fromPath = matchPath.replace(/\*.*/, '*') ?? path
       const toPath = mode === `SSR` ? `/.netlify/functions/__ssr` : `/.netlify/functions/__dsg`
       count++
       rewrites.push(
@@ -94,7 +94,7 @@ export const onPostBuild = async ({ store, pathPrefix, reporter }: any, userPlug
     }
     if (pluginOptions.generateMatchPathRewrites && matchPath && matchPath !== path) {
       rewrites.push({
-        fromPath: matchPath,
+        fromPath: matchPath.replace(/\*.*/, '*'),
         toPath: path,
       })
     }

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -76,9 +76,12 @@ export const onPostBuild = async ({ store, pathPrefix, reporter }: any, userPlug
 
   ;[...pages.values()].forEach((page) => {
     const { mode, matchPath, path } = page
+    const matchPathClean = matchPath && matchPath.replace(/\*.*/, '*')
+    const matchPathIsNotPath = matchPath && matchPath !== path
+
     if (mode === `SSR` || mode === `DSG`) {
       needsFunctions = true
-      const fromPath = matchPath.replace(/\*.*/, '*') ?? path
+      const fromPath = matchPathClean ?? path
       const toPath = mode === `SSR` ? `/.netlify/functions/__ssr` : `/.netlify/functions/__dsg`
       count++
       rewrites.push(
@@ -91,9 +94,9 @@ export const onPostBuild = async ({ store, pathPrefix, reporter }: any, userPlug
           toPath,
         },
       )
-    } else if (pluginOptions.generateMatchPathRewrites && matchPath && matchPath !== path) {
+    } else if (pluginOptions.generateMatchPathRewrites && matchPathIsNotPath) {
       rewrites.push({
-        fromPath: matchPath.replace(/\*.*/, '*'),
+        fromPath: matchPathClean,
         toPath: path,
       })
     }

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -91,8 +91,7 @@ export const onPostBuild = async ({ store, pathPrefix, reporter }: any, userPlug
           toPath,
         },
       )
-    }
-    if (pluginOptions.generateMatchPathRewrites && matchPath && matchPath !== path) {
+    } else if (pluginOptions.generateMatchPathRewrites && matchPath && matchPath !== path) {
       rewrites.push({
         fromPath: matchPath.replace(/\*.*/, '*'),
         toPath: path,


### PR DESCRIPTION
The plugin redirects SSR/DSG pages to the relevant handler function, but was failing for SSR/DSG pages using filesystem routing named splats, because the param name was being incorrectly output in the fromPath of the redirect.

This PR ensures that redirects contains only the splat and the named param is only forwarded to the handler function.

In addition, this PR ensures that SSG client-only routes aren't also erroneously output alongside SSR/DSG redirects when using file system routing.