### PR TITLE
chore: Remove lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "fs-extra": "^10.0.0",
     "gatsby-core-utils": "^3.5.2",
     "kebab-hash": "^0.1.2",
-    "lodash": "^4.17.21",
     "lodash.mergewith": "^4.6.2",
     "webpack-assets-manifest": "^5.0.6"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gatsby-core-utils": "^3.5.2",
     "kebab-hash": "^0.1.2",
     "lodash": "^4.17.21",
+    "lodash.mergewith": "^4.6.2",
     "webpack-assets-manifest": "^5.0.6"
   },
   "devDependencies": {

--- a/src/build-headers-program.ts
+++ b/src/build-headers-program.ts
@@ -332,8 +332,8 @@ const writeHeadersFile =
   }: any) =>
   (contents: any) => writeFile(publicFolder(NETLIFY_HEADERS_FILENAME), contents)
 
-const buildHeadersProgram = (pluginData: any, pluginOptions: any, reporter: any) =>
-  flow(
+const buildHeadersProgram = (pluginData: any, pluginOptions: any, reporter: any) => {
+  const returnVal = flow(
     [
     validateUserOptions(pluginOptions, reporter),
     mapUserLinkHeaders(pluginData),
@@ -345,6 +345,9 @@ const buildHeadersProgram = (pluginData: any, pluginOptions: any, reporter: any)
     transformToString,
     writeHeadersFile(pluginData),
     ])(pluginOptions.headers)
+    console.log({returnVal})
+    return returnVal
+  }
 
 export default buildHeadersProgram
 /* eslint-enable max-lines */

--- a/src/build-headers-program.ts
+++ b/src/build-headers-program.ts
@@ -319,7 +319,10 @@ const applyTransformHeaders =
   ({
     transformHeaders
   }: any) =>
-  (headers: any) => _.mapValues(headers, transformHeaders)
+  (headers: any) =>  Object.fromEntries(
+      Object.entries(headers).map(([key, value]) => [key, transformHeaders(value)])
+    )
+  
 
 const transformToString = (headers: any) => `${HEADER_COMMENT}\n\n${stringifyHeaders(headers)}`
 

--- a/src/build-headers-program.ts
+++ b/src/build-headers-program.ts
@@ -97,7 +97,7 @@ const preloadHeadersByPage = ({
   }
 
   pages.forEach((page: any) => {
-    const scripts = _.flatMap(COMMON_BUNDLES, (file) => getScriptPath(file, manifest))
+    const scripts = COMMON_BUNDLES.flatMap((file) => getScriptPath(file, manifest))
     scripts.push(
       ...getScriptPath(pathChunkName(page.path), manifest),
       ...getScriptPath(page.componentChunkName, manifest),

--- a/src/build-headers-program.ts
+++ b/src/build-headers-program.ts
@@ -22,7 +22,7 @@ const getHeaderName = (header: any) => {
 }
 
 const validHeaders = (headers: any, reporter: any) => {
-  if (!headers || !_.isObject(headers)) {
+  if (!headers || typeof headers !== 'object') {
     return false
   }
 

--- a/src/build-headers-program.ts
+++ b/src/build-headers-program.ts
@@ -15,6 +15,7 @@ import {
   NETLIFY_HEADERS_FILENAME,
   PAGE_DATA_DIR,
 } from './constants'
+import { isBoolean } from './util'
 
 const getHeaderName = (header: any) => {
   const matches = header.match(/^([^:]+):/)
@@ -196,7 +197,7 @@ const validateUserOptions = (pluginOptions: any, reporter: any) => (headers: any
   }
 
   [`mergeSecurityHeaders`, `mergeLinkHeaders`, `mergeCachingHeaders`].forEach((mergeOption) => {
-    if (!_.isBoolean(pluginOptions[mergeOption])) {
+    if (!isBoolean(pluginOptions[mergeOption])) {
       throw new TypeError(
         `The "${mergeOption}" option to gatsby-plugin-netlify must be a boolean. Check your gatsby-config.js.`,
       )

--- a/src/build-headers-program.ts
+++ b/src/build-headers-program.ts
@@ -317,9 +317,11 @@ const applyTransformHeaders =
   ({
     transformHeaders
   }: any) =>
-  (headers: any) =>  Object.fromEntries(
-      Object.entries(headers).map(([key, value]) => [key, transformHeaders(value)])
-    )
+  (headers: any) =>  
+    Object.entries(headers).reduce((temp, [key, value]) => {
+      temp[key] = transformHeaders(value)
+      return temp
+    }, {})
   
 
 const transformToString = (headers: any) => `${HEADER_COMMENT}\n\n${stringifyHeaders(headers)}`

--- a/src/build-headers-program.ts
+++ b/src/build-headers-program.ts
@@ -125,16 +125,14 @@ const preloadHeadersByPage = ({
   return linksByPage
 }
 
-const defaultMerge = (...headers: any[]) => {
-  const unionMerge = (objValue: any, srcValue: any) => {
-    if (Array.isArray(objValue)) {
-      return _.union(objValue, srcValue)
-    }
-    // opt into default merge behavior
+const unionMerge = (objValue: any, srcValue: any) => {
+  if (Array.isArray(objValue)) {
+    return [...new Set([...objValue, ...srcValue])]
   }
-
-  return _.mergeWith({}, ...headers, unionMerge)
+  // opt into default merge behavior
 }
+
+const defaultMerge = (...headers: any[]) => _.mergeWith({}, ...headers, unionMerge)
 
 const headersMerge = (userHeaders: any, defaultHeaders: any) => {
   const merged = {}

--- a/src/build-headers-program.ts
+++ b/src/build-headers-program.ts
@@ -315,7 +315,7 @@ const applyCachingHeaders =
     return defaultMerge(headers, cachingHeaders, CACHING_HEADERS)
   }
 
-const applyTransfromHeaders =
+const applyTransformHeaders =
   ({
     transformHeaders
   }: any) =>
@@ -337,7 +337,7 @@ const buildHeadersProgram = (pluginData: any, pluginOptions: any, reporter: any)
     applyCachingHeaders(pluginData, pluginOptions),
     mapUserLinkAllPageHeaders(pluginData, pluginOptions),
     applyLinkHeaders(pluginData, pluginOptions),
-    applyTransfromHeaders(pluginOptions),
+    applyTransformHeaders(pluginOptions),
     transformToString,
     writeHeadersFile(pluginData),
   )(pluginOptions.headers)

--- a/src/build-headers-program.ts
+++ b/src/build-headers-program.ts
@@ -3,7 +3,6 @@ import { parse, posix } from 'path'
 
 import { writeFile, existsSync } from 'fs-extra'
 import kebabHash from 'kebab-hash'
-import _ from 'lodash'
 import mergeWith from 'lodash.mergewith'
 
 import {
@@ -16,7 +15,7 @@ import {
   NETLIFY_HEADERS_FILENAME,
   PAGE_DATA_DIR,
 } from './constants'
-import { isBoolean } from './util'
+import { isBoolean, flow } from './util'
 
 const getHeaderName = (header: any) => {
   const matches = header.match(/^([^:]+):/)
@@ -332,7 +331,8 @@ const writeHeadersFile =
   (contents: any) => writeFile(publicFolder(NETLIFY_HEADERS_FILENAME), contents)
 
 const buildHeadersProgram = (pluginData: any, pluginOptions: any, reporter: any) =>
-  _.flow(
+  flow(
+    [
     validateUserOptions(pluginOptions, reporter),
     mapUserLinkHeaders(pluginData),
     applySecurityHeaders(pluginOptions),
@@ -342,7 +342,7 @@ const buildHeadersProgram = (pluginData: any, pluginOptions: any, reporter: any)
     applyTransformHeaders(pluginOptions),
     transformToString,
     writeHeadersFile(pluginData),
-  )(pluginOptions.headers)
+    ])(pluginOptions.headers)
 
 export default buildHeadersProgram
 /* eslint-enable max-lines */

--- a/src/build-headers-program.ts
+++ b/src/build-headers-program.ts
@@ -4,6 +4,7 @@ import { parse, posix } from 'path'
 import { writeFile, existsSync } from 'fs-extra'
 import kebabHash from 'kebab-hash'
 import _ from 'lodash'
+import mergeWith from 'lodash.mergewith'
 
 import {
   HEADER_COMMENT,
@@ -132,7 +133,7 @@ const unionMerge = (objValue: any, srcValue: any) => {
   // opt into default merge behavior
 }
 
-const defaultMerge = (...headers: any[]) => _.mergeWith({}, ...headers, unionMerge)
+const defaultMerge = (...headers: any[]) => mergeWith({}, ...headers, unionMerge)
 
 const headersMerge = (userHeaders: any, defaultHeaders: any) => {
   const merged = {}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,3 @@
-import _ from 'lodash'
-
 // Gatsby values
 export const BUILD_HTML_STAGE = `build-html`
 export const BUILD_CSS_STAGE = `build-css`
@@ -14,7 +12,7 @@ export const DEFAULT_OPTIONS = {
   mergeSecurityHeaders: true,
   mergeLinkHeaders: true,
   mergeCachingHeaders: true,
-  transformHeaders: _.identity,
+  transformHeaders: (value) => value,
   generateMatchPathRewrites: true,
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,19 +6,26 @@ export const isBoolean = (val: any): boolean => typeof val === 'boolean' ||
       typeof val.valueOf() === 'boolean'
     )
 
+type Header = string
+type Headers = Header[] 
+
+// TODO: better return type
+type FlowableFunction = (...flowArgs: Headers) => any;
 /**
  * 
  * @param functions - takes in an array of functions
  * @returns The function documented below
  */
 export const flow =
-functions =>
+<FlowReturnType = Promise<any>>(functions: FlowableFunction[]) =>
   /**
    * 
-   * @param args - In our case, args is only {pluginOptions.headers} (in build-headers-program.ts), 
+   * @param headers - In our case, headers is only {pluginOptions.headers} (in build-headers-program.ts), 
    * but in this generic implementation could take in any number of arguments
+   * 
    * @returns The evaluated return value of the last function from the array of functions provided in the
    *  {functions} parameter
    */
-  (...args) =>
-  functions.reduce((prev, fnc) => [fnc(...prev)], args)[0]
+  (...headers: Headers): FlowReturnType => functions.reduce((resultOfPrev, func) => [func(...resultOfPrev)], headers)[0]
+
+  

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,4 @@
+// Accounting for true, false, and new Boolean()
 export const isBoolean = (val: any): boolean => typeof val === 'boolean' ||
     (
       typeof val === 'object' &&

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,3 +4,8 @@ export const isBoolean = (val: any): boolean => typeof val === 'boolean' ||
       val !== null &&
       typeof val.valueOf() === 'boolean'
     )
+
+export const flow =
+  funcs =>
+  (...args) =>
+    funcs.reduce((prev, fnc) => [fnc(...prev)], args)[0]

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,18 @@ export const isBoolean = (val: any): boolean => typeof val === 'boolean' ||
       typeof val.valueOf() === 'boolean'
     )
 
+/**
+ * 
+ * @param functions - takes in an array of functions
+ * @returns 
+ */
 export const flow =
-  funcs =>
+functions =>
+  /**
+   * 
+   * @param args - In our case, args is only {pluginOptions.headers} (in build-headers-program.ts), 
+   * but in this generic implementation could take in any number of arguments
+   * @returns The evaluated return value of the last function
+   */
   (...args) =>
-    funcs.reduce((prev, fnc) => [fnc(...prev)], args)[0]
+  functions.reduce((prev, fnc) => [fnc(...prev)], args)[0]

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,6 @@
+export const isBoolean = (val: any): boolean => typeof val === 'boolean' ||
+    (
+      typeof val === 'object' &&
+      val !== null &&
+      typeof val.valueOf() === 'boolean'
+    )

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,7 +9,7 @@ export const isBoolean = (val: any): boolean => typeof val === 'boolean' ||
 /**
  * 
  * @param functions - takes in an array of functions
- * @returns 
+ * @returns The function documented below
  */
 export const flow =
 functions =>
@@ -17,7 +17,8 @@ functions =>
    * 
    * @param args - In our case, args is only {pluginOptions.headers} (in build-headers-program.ts), 
    * but in this generic implementation could take in any number of arguments
-   * @returns The evaluated return value of the last function
+   * @returns The evaluated return value of the last function from the array of functions provided in the
+   *  {functions} parameter
    */
   (...args) =>
   functions.reduce((prev, fnc) => [fnc(...prev)], args)[0]

--- a/yarn.lock
+++ b/yarn.lock
@@ -9158,6 +9158,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash.mergewith@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9190,7 +9190,7 @@ lodash.zip@^4.2.0:
 
 lodash@4.17.21, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
   version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.0.0, loose-envify@^1.4.0:


### PR DESCRIPTION
This removes (most) of the lodash we have in this repo. I kept `mergeWith` as there wasn't any simple ES6/quick fix I could write up to replace this function, so I opted to only include the `lodash.mergewith` package, instead of all of lodash.

Closes: #129 