### PR TITLE
chore: remove error for no-unused-vars

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,6 @@ module.exports = {
     'no-param-reassign': 0,
     'no-promise-executor-return': 0,
     'no-prototype-builtins': 0,
-    'no-unused-vars': ['error', { ignoreRestSiblings: true }],
     'unicorn/filename-case': 0,
     'unicorn/numeric-separators-style': 0,
     'unicorn/no-empty-file': 0,


### PR DESCRIPTION
The `no-unused-vars` eslint rule causes issues with Typescript, such as flagging an issue with `flowArgs` below being "unused".
```
type FlowableFunction = (...flowArgs: Headers) => any;
```

I checked in our next&gatsby plugins, and the gatsby plugin does not explicitly say to error as we were doing here (`no-unused-vars` is not mentioned at all in .eslintrc), and the next plugin explicitly turns *off* this rule (`'no-unused-vars': 0`), so I have removed this one as well.

I've created a draft issue in our board for us to think about getting all of our repos aligned in regards to the .eslintrc.js files. 