### PR TITLE
chore: Remove console log

### DIFF
--- a/src/build-headers-program.ts
+++ b/src/build-headers-program.ts
@@ -332,8 +332,8 @@ const writeHeadersFile =
   }: any) =>
   (contents: any) => writeFile(publicFolder(NETLIFY_HEADERS_FILENAME), contents)
 
-const buildHeadersProgram = (pluginData: any, pluginOptions: any, reporter: any) => {
-  const returnVal = flow(
+const buildHeadersProgram = (pluginData: any, pluginOptions: any, reporter: any) => 
+  flow(
     [
     validateUserOptions(pluginOptions, reporter),
     mapUserLinkHeaders(pluginData),
@@ -345,9 +345,7 @@ const buildHeadersProgram = (pluginData: any, pluginOptions: any, reporter: any)
     transformToString,
     writeHeadersFile(pluginData),
     ])(pluginOptions.headers)
-    console.log({returnVal})
-    return returnVal
-  }
+  
 
 export default buildHeadersProgram
 /* eslint-enable max-lines */


### PR DESCRIPTION
Missed removing a testing console.log (and associated return reformatting) from https://github.com/netlify/gatsby-plugin-netlify/pull/130/ :woman-facepalming: 
