### PR TITLE
test: downgrade netlify-cli

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: '*'
       - name: Install Netlify CLI
-        run: npm install -g netlify-cli
+        run: npm install -g netlify-cli@^11
       - name: Install dependencies
         run: yarn install --ignore-engines
       - name: Run tests


### PR DESCRIPTION
Tests are running on Node 14.15 and `netlify-cli` fails installation on that node version (see https://github.com/netlify/gatsby-plugin-netlify/actions/runs/4400223936/jobs/7705326829 for example) - this downgrades by 2 majors (previous major also fails on that node version).

`netlify-cli` 's package.json mention that minimum node version is 14.16 - but it fails to be installed on that version as well - seems like due to `node:fs` imports that are not supported yet