### PR TITLE
chore: add gh workflow to add zenhub label

### DIFF
--- a/.github/workflows/add-zenhub-label.yml
+++ b/.github/workflows/add-zenhub-label.yml
@@ -1,0 +1,24 @@
+# Ensure we add the correct ZenHub label for all new issues
+# Avoids problem where checklist issues are not added to the correct ZenHub pipeline
+
+name: Add ZenHub label to issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["Ecosystem: Frameworks"]
+            })


### PR DESCRIPTION
## Description

Adds `Ecosystem: Frameworks` label for all created issues to ensure it appears on the correct ZenHub workspace. Issues which are created using GitHub checklists didn't apply the issue template and the label was missing.

### Documentation

N/A

## Tests

N/A

## Relevant links (GitHub issues, etc.) or a picture of cute animal

![image](https://github.com/netlify/gatsby-plugin-netlify/assets/1965510/f83a5ba1-588d-44e3-8e06-87c2c37be493)

Related issue: https://github.com/netlify/pod-ecosystem-frameworks/issues/507
